### PR TITLE
fix(richesse): path real /var/www/richesseclub (Caddyfile da VM)

### DIFF
--- a/.github/workflows/richesse-deploy.yml
+++ b/.github/workflows/richesse-deploy.yml
@@ -1,7 +1,7 @@
 # Richesse Club - Deploy automatico para Oracle VPS
 # Site estatico: 77 HTMLs + site.js + styles.css + sitemap/robots/llms.
 # Polla HEAD do branch main do richesse-club a cada 5 min.
-# Se SHA mudou: ssh para Oracle, clone-or-pull em /home/ubuntu/apps/richesse-club, rsync para /opt/richesse-club/static.
+# Se SHA mudou: ssh para Oracle, clone-or-pull em /home/ubuntu/apps/richesse-club, rsync para /var/www/richesseclub.
 #
 # Pre-requisitos (secrets em actions-engine):
 #   ORACLE_SSH_KEY - chave privada SSH (openclaw_do) base64 encoded
@@ -95,7 +95,7 @@ jobs:
              fi
              HEAD_SHORT=\$(git rev-parse --short HEAD)
              echo \"Pulled: \$HEAD_SHORT\"
-             sudo mkdir -p /opt/richesse-club/static
+             sudo mkdir -p /var/www/richesseclub
              sudo rsync -a --delete \
                --include='*.html' \
                --include='site.js' \
@@ -125,15 +125,15 @@ jobs:
                --exclude='.gitignore' \
                --exclude='.gitattributes' \
                --exclude='caddy-*' \
-               \"\$REPO_DIR/\" /opt/richesse-club/static/
+               \"\$REPO_DIR/\" /var/www/richesseclub/
              # Forca mtime atual (rsync -a preserva mtime do clone, o que mantem Caddy file_server cache)
-             sudo find /opt/richesse-club/static -type f -exec touch {} +
+             sudo find /var/www/richesseclub -type f -exec touch {} +
              # Reload Caddy pra invalidar file descriptor cache (sem downtime)
              sudo systemctl reload caddy || true
-             echo '--- /opt/richesse-club/static/ post-deploy:'
-             ls -la /opt/richesse-club/static/site.js /opt/richesse-club/static/index.html 2>/dev/null | awk '{print \$5, \$9}'
+             echo '--- /var/www/richesseclub/ post-deploy:'
+             ls -la /var/www/richesseclub/site.js /var/www/richesseclub/index.html 2>/dev/null | awk '{print \$5, \$9}'
              echo '--- site.js build marker:'
-             grep -E 'RICHESSE_BUILD' /opt/richesse-club/static/site.js | head -1
+             grep -E 'RICHESSE_BUILD' /var/www/richesseclub/site.js | head -1
              echo '--- origin probe:'
              curl -fsS -o /tmp/sj-probe.js http://127.0.0.1/site.js -H 'Host: richesseclub.com' && \
                echo \"served size: \$(wc -c < /tmp/sj-probe.js) bytes\" && \


### PR DESCRIPTION
Diagnose mostrou que Caddyfile na VM tem 'root * /var/www/richesseclub'. PR #49 mudou pra /opt/richesse-club/static que era apenas template do repo. Por isso rsync ia pra path correto mas Caddy nunca pegava. Reverte para /var/www/richesseclub mantendo touch + reload caddy do PR #50.